### PR TITLE
Update Balance.swift

### DIFF
--- a/StripeAPI/Models/CORE_RESOURCES/Balance.swift
+++ b/StripeAPI/Models/CORE_RESOURCES/Balance.swift
@@ -23,7 +23,7 @@ public struct Balance: StripeModel, ListProtocol {
 
     public let object: String
     public let available: [Transaction]
-    public let connectReserved: [ConnectReserved]
+    public let connectReserved: [ConnectReserved]?
     public let livemode: Bool
     public let pending: [Transaction]
 


### PR DESCRIPTION
I just fixed Balance.swift in order to decode successfully when response didn't have `connect_reserved`.